### PR TITLE
fingerprint에 ocfDeviceType 추가

### DIFF
--- a/devicetypes/woobooung/dawondns-smartplug.src/dawondns-smartplug.groovy
+++ b/devicetypes/woobooung/dawondns-smartplug.src/dawondns-smartplug.groovy
@@ -32,9 +32,10 @@ metadata {
         capability "Switch"
         capability "Health Check"
 
-        fingerprint endpointId: "0x01", profileId: "0104", deviceId: "0051", inClusters: "0000, 0002, 0003, 0004, 0006, 0019, 0702, 0B04, 0008, 0009", outClusters: "0000, 0002, 0003, 0004, 0006, 0019, 0702, 0B04, 0008, 0009", manufacturer: "DAWON_DNS", model: "PM-B530-ZB", deviceJoinName: "DAWON SmartPlug 16A" 
-        fingerprint endpointId: "0x01", profileId: "0104", deviceId: "0051", inClusters: "0000, 0004, 0003, 0006, 0019, 0702, 0B04", outClusters: "0000, 0004, 0003, 0006, 0019, 0702, 0B04", manufacturer: "DAWON_DNS", model: "PM-B430-ZB", deviceJoinName: "DAWON SmartPlug 10A" 
-        fingerprint endpointId: "0x01", profileId: "0104", deviceId: "0051", inClusters: "0000, 0002, 0003, 0004, 0006, 0019, 0702, 0B04, 0008, 0009", outClusters: "0000, 0002, 0003, 0004, 0006, 0019, 0702, 0B04, 0008, 0009", manufacturer: "DAWON_DNS", model: "PM-C140-ZB", deviceJoinName: "DAWON Embeded Plug" 
+        //added 'ocfDeviceType: "oic.d.smartplug"' so that the device is still recognized as plug after changing the DTH to different one.
+        fingerprint endpointId: "0x01", profileId: "0104", deviceId: "0051", inClusters: "0000, 0002, 0003, 0004, 0006, 0019, 0702, 0B04, 0008, 0009", outClusters: "0000, 0002, 0003, 0004, 0006, 0019, 0702, 0B04, 0008, 0009", manufacturer: "DAWON_DNS", model: "PM-B530-ZB", deviceJoinName: "DAWON SmartPlug 16A", ocfDeviceType: "oic.d.smartplug"
+        fingerprint endpointId: "0x01", profileId: "0104", deviceId: "0051", inClusters: "0000, 0004, 0003, 0006, 0019, 0702, 0B04", outClusters: "0000, 0004, 0003, 0006, 0019, 0702, 0B04", manufacturer: "DAWON_DNS", model: "PM-B430-ZB", deviceJoinName: "DAWON SmartPlug 10A", ocfDeviceType: "oic.d.smartplug" 
+        fingerprint endpointId: "0x01", profileId: "0104", deviceId: "0051", inClusters: "0000, 0002, 0003, 0004, 0006, 0019, 0702, 0B04, 0008, 0009", outClusters: "0000, 0002, 0003, 0004, 0006, 0019, 0702, 0B04, 0008, 0009", manufacturer: "DAWON_DNS", model: "PM-C140-ZB", deviceJoinName: "DAWON Embeded Plug", ocfDeviceType: "oic.d.smartplug" 
     }
 
     preferences {


### PR DESCRIPTION
fingerprint 구문에 ocfDeviceType를 'oic.d.smartplug'로 정의하면 Device Type를 임의의 다른 종류로 변경하더라도(예를들어 'Zigbee Switch Power') 클래식앱과 뉴앱 모두에서 '스위치'가 아닌 '플러그' 아이콘으로 표시됩니다. 이미 추가된 경우 장치를 최초 1회 본 DTH로 변경해야 플러그 아이콘이 적용됩니다. 또한 구글 홈 연동시에도 별도 장치 이름 변경 없이 '스위치'가 아닌 '콘센트'로 인식됩니다.
If ocfDeviceType is defined as 'oic.d.smartplug' in fingerprint section, even when Device Type is changed to other DTH such as 'Zigbee Switch Power', the device icon still shows up as 'Plug', not 'Switch' in both the Classic and the New Smartthings application. If the device is already registered, it has to be at least once changed to this DTH for the plug icon to be applied. The device is also recognized as 'Outlet' not 'Switch' with out changing the label.